### PR TITLE
Add Expo config plugin for Apple Sign-In support

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,28 @@
+// set Info.plist values
+import configPlugin from '@expo/config-plugins';
+
+const {createRunOncePlugin, withEntitlementsPlist, withInfoPlist} = configPlugin
+
+const withAllowMixedLocalizations = function (config) {
+  return withInfoPlist(config, function (config) {
+    config.modResults.CFBundleAllowMixedLocalizations =
+      config.modResults.CFBundleAllowMixedLocalizations ?? true;
+
+    return config;
+  });
+};
+
+const withDefaultAppleSignIn = function (config) {
+  config = withAllowMixedLocalizations(config);
+  return withEntitlementsPlist(config, function (config) {
+    config.modResults['com.apple.developer.applesignin'] = ['Default'];
+    return config;
+  });
+};
+
+const withAppleSignin = (config) => {
+  config = withDefaultAppleSignIn(config);
+  return config;
+};
+
+export default createRunOncePlugin(withAppleSignin, 'apple-signin');

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cpp",
     "*.podspec",
     "react-native.config.js",
+    "app.plugin.js",
     "!ios/build",
     "!android/build",
     "!android/gradle",


### PR DESCRIPTION
@benjamineruvieru 
Thank you for creating this library! 
I noticed that the library lacks an expo plugin to set Info.plist variables, which is necessary to make "Apple Sign-In" feature work. (at least in my environment)
I added a file that I use in my app.